### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "managedidentities",
     "name_pretty": "Managed Service for Microsoft Active Directory",
     "product_documentation": "https://cloud.google.com/managed-microsoft-ad/",
-    "client_documentation": "https://googleapis.dev/python/managedidentities/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/managedidentities/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ on-premises AD domain to the cloud.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-managed-identities.svg
    :target: https://pypi.org/project/google-cloud-managed-identities/
 .. _Managed Service for Microsoft Active Directory: https://cloud.google.com/managed-microsoft-ad/
-.. _Client Library Documentation: https://googleapis.dev/python/managedidentities/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/managedidentities/latest
 .. _Product Documentation:  https://cloud.google.com/managed-microsoft-ad/
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.